### PR TITLE
Add Framebuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dev-dependencies]
+winit= { version="0.22", features = ["web-sys"] }
 
 [dependencies]
 wgpu={ git="https://github.com/gfx-rs/wgpu-rs" }
+raw-window-handle = "0.3"
 
 # Native deps
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -3,20 +3,16 @@ use wgpu;
 use wgpu_util;
 
 async fn app() {
-    let instance = wgpu::Instance::new();
-    let _adapter = instance
-        .request_adapter(
-            &wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::Default,
-                compatible_surface: None, //Some(&surface),
-            },
-            wgpu::BackendBit::PRIMARY,
-        )
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::Default,
+            compatible_surface: None, //Some(&surface),
+        })
         .await
         .unwrap();
 
-    // unimplemented!() in master
-    // println!("Adapter: {}", adapter.get_info().name);
+    println!("Adapter: {}", adapter.get_info().name);
 }
 
 fn main() {

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -1,0 +1,115 @@
+use wgpu;
+
+use wgpu_util;
+use winit::{
+    self,
+    event::{
+        self,
+        Event::{self},
+        WindowEvent,
+    },
+    event_loop,
+};
+
+fn frame(device: &wgpu::Device, framebuffer: &mut wgpu_util::Framebuffer) -> wgpu::CommandBuffer {
+    let mut encoder =
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+    {
+        let _pass = framebuffer.begin_render_pass(&mut encoder);
+    }
+
+    encoder.finish()
+}
+
+async fn app() {
+    let instance = wgpu::Instance::new();
+    let adapter = instance
+        .request_adapter(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::Default,
+                compatible_surface: None, //Some(&surface),
+            },
+            wgpu::BackendBit::PRIMARY,
+        )
+        .await
+        .unwrap();
+
+    let (device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                extensions: wgpu::Extensions {
+                    anisotropic_filtering: false,
+                },
+                limits: wgpu::Limits::default(),
+            },
+            /*        match trace_dir {
+                Ok(ref value) if !cfg!(feature = "trace") => {
+                    log::error!("Unable to trace into {:?} without \"trace\" feature enabled!", value);
+                    None
+                }
+                Ok(ref value) => Some(std::path::Path::new(value)),
+                Err(_) => None,
+            },*/
+            None,
+        )
+        .await
+        .unwrap();
+    let builder = winit::window::WindowBuilder::new();
+    let event_loop = winit::event_loop::EventLoop::new();
+    let window = builder.with_visible(false).build(&event_loop).unwrap();
+
+    let mut framebuffer = wgpu_util::Framebuffer::new(&instance, &window);
+
+    let sz = window.inner_size();
+    framebuffer.resize(&device, sz.width, sz.height, true);
+
+    framebuffer.set_clear_color(&[0.7, 0.3, 0.2, 1.0]);
+
+    // Render first frame, and make window visible only after,
+    // so we don't get a flash of empty window
+    // TODO: It seems it is enough to just have a set_visible call, as
+    // long as it was created as hidden, but need to check other platforms
+    // (tested on osx)
+    let cmd_buf = frame(&device, &mut framebuffer);
+    queue.submit(Some(cmd_buf));
+    window.set_visible(true);
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::MainEventsCleared => {
+            window.request_redraw();
+        }
+        Event::RedrawRequested(_) => {
+            let cmd_buf = frame(&device, &mut framebuffer);
+
+            queue.submit(Some(cmd_buf));
+        }
+        Event::WindowEvent {
+            event: WindowEvent::Resized(size),
+            ..
+        } => {
+            framebuffer.resize(&device, size.width, size.height, true);
+        }
+        Event::WindowEvent { event, .. } => match event {
+            WindowEvent::KeyboardInput {
+                input:
+                    event::KeyboardInput {
+                        virtual_keycode: Some(event::VirtualKeyCode::Escape),
+                        state: event::ElementState::Pressed,
+                        ..
+                    },
+                ..
+            }
+            | event::WindowEvent::CloseRequested => {
+                *control_flow = event_loop::ControlFlow::Exit;
+            }
+            _ => {}
+        },
+
+        _ => {}
+    });
+}
+
+fn main() {
+    wgpu_util::block_on(app);
+}

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -55,7 +55,11 @@ async fn app() {
     let event_loop = winit::event_loop::EventLoop::new();
     let window = builder.with_visible(false).build(&event_loop).unwrap();
 
-    let mut framebuffer = wgpu_util::Framebuffer::new_from_window(&instance, &window, wgpu::TextureFormat::Bgra8UnormSrgb);
+    let mut framebuffer = wgpu_util::Framebuffer::new_from_window(
+        &instance,
+        &window,
+        wgpu::TextureFormat::Bgra8UnormSrgb,
+    );
 
     let mut tex_fb = wgpu_util::Framebuffer::new_with_texture(wgpu::TextureFormat::Rgba8UnormSrgb);
 
@@ -63,7 +67,7 @@ async fn app() {
 
     let sz = window.inner_size();
     framebuffer.set_resolution(sz.width, sz.height);
-    framebuffer.set_depth_format(wgpu::TextureFormat::Depth24Plus);
+    framebuffer.set_depth_stencil_format(Some(wgpu::TextureFormat::Depth24Plus));
     framebuffer.assemble(&device);
 
     framebuffer.set_clear_color(&[0.7, 0.3, 0.2, 1.0]);

--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -57,7 +57,7 @@ async fn app() {
 
     let mut framebuffer = wgpu_util::Framebuffer::new_from_window(&instance, &window);
 
-    let mut tex_fb = wgpu_util::Framebuffer::new_texture(wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut tex_fb = wgpu_util::Framebuffer::new_with_texture(wgpu::TextureFormat::Rgba8UnormSrgb);
 
     tex_fb.set_clear_color(&[0.2, 0.3, 0.7, 1.0]);
 

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,0 +1,125 @@
+pub struct Framebuffer {
+    surface: wgpu::Surface,
+    swap_chain: Option<wgpu::SwapChain>,
+    frame: Option<wgpu::SwapChainOutput>,
+    depth_texture_view: Option<wgpu::TextureView>,
+    clear_color: [f64; 4],
+    resolution: (u32, u32),
+}
+
+impl Framebuffer {
+    pub fn new<W: raw_window_handle::HasRawWindowHandle>(
+        instance: &wgpu::Instance,
+        window: &W,
+    ) -> Framebuffer {
+        let surface = unsafe { instance.create_surface(window) };
+
+        Framebuffer {
+            surface,
+            swap_chain: None,
+            frame: None,
+            depth_texture_view: None,
+            clear_color: [0f64, 0f64, 0f64, 1f64],
+            resolution: (0, 0),
+        }
+    }
+
+    pub fn set_clear_color(&mut self, clear_color: &[f64; 4]) {
+        self.clear_color = *clear_color;
+    }
+
+    pub fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32, depth_enabled: bool) {
+        if width == self.resolution.0
+            && height == self.resolution.1
+            && depth_enabled == self.depth_texture_view.is_some()
+        {
+            // Nothing changed
+            return;
+        }
+
+        self.frame = None;
+
+        self.resolution = (width, height);
+        let sc_desc = wgpu::SwapChainDescriptor {
+            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            // TODO: Allow srgb unconditionally
+            format: if cfg!(target_arch = "wasm32") {
+                wgpu::TextureFormat::Bgra8Unorm
+            } else {
+                wgpu::TextureFormat::Bgra8UnormSrgb
+            },
+            width: width,
+            height: height,
+            present_mode: wgpu::PresentMode::Mailbox,
+        };
+        let swap_chain = device.create_swap_chain(&self.surface, &sc_desc);
+        self.swap_chain = Some(swap_chain);
+
+        if depth_enabled {
+            self.depth_texture_view = Some(
+                device
+                    .create_texture(&wgpu::TextureDescriptor {
+                        size: wgpu::Extent3d {
+                            width: width,
+                            height: height,
+                            depth: 1,
+                        },
+                        mip_level_count: 1,
+                        sample_count: 1,
+                        dimension: wgpu::TextureDimension::D2,
+                        format: wgpu::TextureFormat::Depth24Plus,
+                        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                        label: Some("wgpu-util depth texture"),
+                    })
+                    .create_default_view(),
+            );
+        }
+    }
+
+    pub fn begin_render_pass<'a>(
+        &'a mut self,
+        encoder: &'a mut wgpu::CommandEncoder,
+    ) -> wgpu::RenderPass<'a> {
+        // The lifetimes above are telling that the RenderPass must not be
+        // dropped before self or encoder, as the RenderPass will refer to
+        // values in them
+
+        let swap_chain = self.swap_chain.as_mut().expect(
+            "swap chain is missing, did you remember to call `resize` before `begin_render_pass`",
+        );
+        self.frame = None;
+        let frame = swap_chain
+            .get_next_texture()
+            .expect("Timeout when acquiring next swap chain texture");
+
+        self.frame = Some(frame);
+        let frame_view = &self.frame.as_mut().unwrap().view;
+
+        let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                attachment: frame_view,
+                resolve_target: None,
+                load_op: wgpu::LoadOp::Clear,
+                store_op: wgpu::StoreOp::Store,
+                clear_color: wgpu::Color {
+                    r: self.clear_color[0],
+                    g: self.clear_color[1],
+                    b: self.clear_color[2],
+                    a: self.clear_color[3],
+                },
+            }],
+            depth_stencil_attachment: self.depth_texture_view.as_ref().map(|tex| {
+                wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                    attachment: tex,
+                    depth_load_op: wgpu::LoadOp::Clear,
+                    depth_store_op: wgpu::StoreOp::Store,
+                    stencil_load_op: wgpu::LoadOp::Clear,
+                    stencil_store_op: wgpu::StoreOp::Store,
+                    clear_depth: 1.0,
+                    clear_stencil: 0,
+                }
+            }),
+        });
+        pass
+    }
+}

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,3 +1,48 @@
+
+/***
+TODO:
+  multisampling support
+    needs to create a intermediate texture, that then is resolved to the ultimate attachment
+  colorformat for surface
+  clearcolor per attachment
+  attachment load/store config?
+  simple configuration thing. Maybe just set_resolution which dirties/invalidates the state
+  begin_render_pass with some config, perhaps the load/store, or not. Which attachment is bound.
+  depth only pass?
+
+  some getters.. num_attachments(), get_attachment_format(idx) ?
+
+
+  or maybe everything is setup with one big descriptor always..
+
+  does multisampling have to be the same on all attachments?
+
+  FramebufferDescriptor {
+      attachments: &[
+          FramebufferAttachment::Surface::from_window(win),
+          FramebufferAttachment::Texture {
+              format: fmt,
+              clear_color: &[0,0,0,0],
+              load_store: ... ??
+          },
+       ],
+      depth_stencil: FramebufferDepthStencil {
+          format: depth_format,
+          depth_clear: 0,
+          depth_store: false,
+          stencil_clear: 0,
+          stencil_store: false
+      },
+      multisample: Some(4),
+      resolution: (256,256)
+  }
+
+***/
+
+
+
+
+
 #[derive(Debug)]
 enum FramebufferAttachment {
     Surface {
@@ -193,14 +238,14 @@ impl Framebuffer {
         }
     }
 
-    pub fn color_format(&self) -> Option<wgpu::TextureFormat> {
-        // TODO:
-        Some(wgpu::TextureFormat::Bgra8UnormSrgb)
-        // Some(wgpu::TextureFormat::Bgra8Unorm)
-    }
-    pub fn sample_count(&self) -> u32 {
-        1 // TODO:
-    }
+    // pub fn color_format(&self) -> Option<wgpu::TextureFormat> {
+    //     // TODO:
+    //     Some(wgpu::TextureFormat::Bgra8UnormSrgb)
+    //     // Some(wgpu::TextureFormat::Bgra8Unorm)
+    // }
+    // pub fn sample_count(&self) -> u32 {
+    //     1 // TODO:
+    // }
 
     pub fn begin_render_pass<'a>(
         &'a mut self,

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,209 +1,206 @@
-
 /***
 TODO:
-  multisampling support
-    needs to create a intermediate texture, that then is resolved to the ultimate attachment
-  colorformat for surface
-  clearcolor per attachment
   attachment load/store config?
-  simple configuration thing. Maybe just set_resolution which dirties/invalidates the state
   begin_render_pass with some config, perhaps the load/store, or not. Which attachment is bound.
   depth only pass?
 
   some getters.. num_attachments(), get_attachment_format(idx) ?
 
 
-  or maybe everything is setup with one big descriptor always..
-
-  does multisampling have to be the same on all attachments?
-
-  FramebufferDescriptor {
-      attachments: &[
-          FramebufferAttachment::Surface::from_window(win),
-          FramebufferAttachment::Texture {
-              format: fmt,
-              clear_color: &[0,0,0,0],
-              load_store: ... ??
-          },
-       ],
-      depth_stencil: FramebufferDepthStencil {
-          format: depth_format,
-          depth_clear: 0,
-          depth_store: false,
-          stencil_clear: 0,
-          stencil_store: false
-      },
-      multisample: Some(4),
-      resolution: (256,256)
-  }
-
 ***/
 
-
-
-
+#[derive(Debug)]
+struct ColorAttachment {
+    data: ColorAttachmentData,
+    color_format: wgpu::TextureFormat,
+    assembled: Option<ColorAttachmentAssembled>,
+    clear_color: [f64; 4],
+}
 
 #[derive(Debug)]
-enum FramebufferAttachment {
+struct ColorAttachmentAssembled {
+    multisample_texture: Option<wgpu::Texture>,
+    attachment_view: Option<wgpu::TextureView>,
+    resolve_view: Option<wgpu::TextureView>,
+}
+#[derive(Debug)]
+enum ColorAttachmentData {
     Surface {
         surface: wgpu::Surface,
         swap_chain: Option<wgpu::SwapChain>,
         frame: Option<wgpu::SwapChainFrame>,
     },
     Texture {
-        color_format: wgpu::TextureFormat,
         color_texture: Option<wgpu::Texture>,
-        texture_view: Option<wgpu::TextureView>,
     },
 }
 #[derive(Debug)]
 pub struct Framebuffer {
-    attachments: Vec<FramebufferAttachment>,
-    depth_texture_view: Option<wgpu::TextureView>,
-    clear_color: [f64; 4],
-    configuration: FramebufferConfiguration,
-}
+    color_attachments: Vec<ColorAttachment>,
+    sample_count: u32,
+    resolution: (u32, u32),
 
-#[derive(Clone, PartialEq, Default, Debug)]
-pub struct FramebufferConfiguration {
-    pub resolution: (u32, u32),
-    pub depth_format: Option<wgpu::TextureFormat>,
-}
+    live_frame: Vec<wgpu::SwapChainFrame>,
 
-impl FramebufferConfiguration {
-    pub fn with_resolution(&self, width: u32, height: u32) -> FramebufferConfiguration {
-        let mut ret = self.clone();
-        ret.resolution = (width, height);
-        ret
-    }
-    pub fn with_depth_format(&self, depth_format: wgpu::TextureFormat) -> FramebufferConfiguration {
-        let mut ret = self.clone();
-        ret.depth_format = Some(depth_format);
-        ret
-    }
-    pub fn with_no_depth(&self) -> FramebufferConfiguration {
-        let mut ret = self.clone();
-        ret.depth_format = None;
-        ret
-    }
-    pub fn width(&self) -> u32 {
-        self.resolution.0
-    }
-    pub fn height(&self) -> u32 {
-        self.resolution.1
-    }
+    depth_stencil_format: Option<wgpu::TextureFormat>,
+    depth_stencil_view: Option<wgpu::TextureView>,
+
+    present_mode: wgpu::PresentMode,
+
+    dirty: bool,
 }
 
 impl Framebuffer {
+    pub fn new() -> Framebuffer {
+        Framebuffer {
+            color_attachments: Vec::new(),
+            depth_stencil_view: None,
+            live_frame: Vec::new(),
+            sample_count: 1,
+            resolution: (0, 0),
+            depth_stencil_format: None,
+            present_mode: wgpu::PresentMode::Mailbox,
+            dirty: true,
+        }
+    }
+
     pub fn new_from_window<W: raw_window_handle::HasRawWindowHandle>(
         instance: &wgpu::Instance,
         window: &W,
+color_format: wgpu::TextureFormat
     ) -> Framebuffer {
         let surface = unsafe { instance.create_surface(window) };
-        Self::new_from_surface(surface)
+        Self::new_from_surface(surface, color_format)
     }
-    pub fn new_from_surface(surface: wgpu::Surface) -> Framebuffer {
-        let mut fb = Framebuffer {
-            attachments: Vec::new(),
-            depth_texture_view: None,
-            clear_color: [0f64, 0f64, 0f64, 1f64],
-            configuration: FramebufferConfiguration::default(), //            resolution: (0, 0),
-        };
-        fb.add_surface_attachment(surface);
+    pub fn new_from_surface(surface: wgpu::Surface, color_format: wgpu::TextureFormat) -> Framebuffer {
+        let mut fb = Framebuffer::new();
+        fb.add_surface_attachment(surface, color_format);
         fb
     }
 
     pub fn new_with_texture(color_format: wgpu::TextureFormat) -> Framebuffer {
-        let mut fb = Framebuffer {
-            attachments: Vec::new(),
-            depth_texture_view: None,
-            clear_color: [0f64, 0f64, 0f64, 1f64],
-            configuration: FramebufferConfiguration::default(),
-        };
+        let mut fb = Framebuffer::new();
         fb.add_texture_attachment(color_format);
         fb
     }
 
-    pub fn add_surface_attachment(&mut self, surface: wgpu::Surface) {
-        self.attachments.push(FramebufferAttachment::Surface {
-            surface,
-            swap_chain: None,
-            frame: None,
+    pub fn add_surface_attachment(&mut self, surface: wgpu::Surface,color_format: wgpu::TextureFormat) {
+        self.color_attachments.push(ColorAttachment {
+            data: ColorAttachmentData::Surface {
+                surface,
+                swap_chain: None,
+                frame: None,
+            },
+            color_format: color_format,
+            assembled: None,
+            clear_color: [0.0, 0.0, 0.0, 0.0f64],
         });
     }
 
     pub fn add_texture_attachment(&mut self, color_format: wgpu::TextureFormat) {
-        self.attachments.push(FramebufferAttachment::Texture {
+        self.color_attachments.push(ColorAttachment {
+            data: ColorAttachmentData::Texture {
+                color_texture: None,
+            },
             color_format,
-            color_texture: None,
-            texture_view: None,
+            assembled: None,
+            clear_color: [0.0, 0.0, 0.0, 0.0f64],
         });
     }
 
-    pub fn configuration(&self) -> &FramebufferConfiguration {
-        &self.configuration
-    }
-
     pub fn set_clear_color(&mut self, clear_color: &[f64; 4]) {
-        self.clear_color = *clear_color;
+        for attachment in &mut self.color_attachments {
+            attachment.clear_color = *clear_color;
+        }
     }
 
-    pub fn reconfigure(
-        &mut self,
-        device: &wgpu::Device,
-        new_configuration: &FramebufferConfiguration,
-    ) {
-        if new_configuration == &self.configuration {
+    pub fn set_sample_count(&mut self, sample_count: u32) {
+        self.sample_count = sample_count;
+        self.dirty = true;
+    }
+
+    pub fn set_depth_format(&mut self, format: wgpu::TextureFormat) {
+        self.depth_stencil_format = Some(format);
+    }
+
+    // Returns sample count, 1 meaning no multisampling
+    pub fn sample_count(&self) -> u32 {
+        self.sample_count
+    }
+
+    // Returns width
+    pub fn width(&self) -> u32 {
+        self.resolution.0
+    }
+
+    // Returns height
+    pub fn height(&self) -> u32 {
+        self.resolution.1
+    }
+
+    // Sets the resolution for all the attachments.
+    // Invalidates resources, requires `assemble`
+    pub fn set_resolution(&mut self, width: u32, height: u32) {
+        self.resolution = (width, height);
+        self.dirty = true;
+    }
+
+    pub fn assemble(&mut self, device: &wgpu::Device) {
+        debug_assert!(
+            !self.needs_present(),
+            "Live swapchain frames that were not presented while reconfiguring!"
+        );
+        if !self.dirty {
             // Nothing changed
             return;
         }
+        self.dirty = false;
 
-        self.configuration = new_configuration.clone(); //resolution = (width, height);
-        let sc_desc = wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
-            // TODO: Allow srgb unconditionally
-            format: if cfg!(target_arch = "wasm32") {
-                wgpu::TextureFormat::Bgra8Unorm
-            } else {
-                wgpu::TextureFormat::Bgra8UnormSrgb
-            },
-            width: self.configuration.width(),
-            height: self.configuration.height(),
-            present_mode: wgpu::PresentMode::Mailbox,
+        let surface_colorformat = if cfg!(target_arch = "wasm32") {
+            wgpu::TextureFormat::Bgra8Unorm
+        } else {
+            wgpu::TextureFormat::Bgra8UnormSrgb
         };
 
-        for attachment in &mut self.attachments {
-            match attachment {
-                FramebufferAttachment::Surface {
+        for attachment in &mut self.color_attachments {
+            let mut output_view = None;
+            match attachment.data {
+                ColorAttachmentData::Surface {
                     ref mut surface,
                     ref mut swap_chain,
                     ref mut frame,
                 } => {
+                    let sc_desc = wgpu::SwapChainDescriptor {
+                        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                        format: attachment.color_format,
+                        width: self.resolution.0,
+                        height: self.resolution.1,
+                        present_mode: self.present_mode,
+                    };
+
                     *frame = None; // SwapChainFrame must be dropped debug creating creating new swapchain
                     let new_swap_chain = device.create_swap_chain(&surface, &sc_desc);
                     *swap_chain = Some(new_swap_chain);
                 }
-                FramebufferAttachment::Texture {
-                    ref color_format,
+                ColorAttachmentData::Texture {
                     ref mut color_texture,
-                    ref mut texture_view,
                 } => {
                     let texture = device.create_texture(&wgpu::TextureDescriptor {
                         label: Some("Framebuffer Texture"),
                         size: wgpu::Extent3d {
-                            width: self.configuration.width(),
-                            height: self.configuration.height(),
+                            width: self.resolution.0,
+                            height: self.resolution.1,
                             depth: 1,
                         },
                         mip_level_count: 1,
                         sample_count: 1,
                         dimension: wgpu::TextureDimension::D2,
-                        format: *color_format,
+                        format: attachment.color_format,
                         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
                     });
                     let tex_view = texture.create_view(&wgpu::TextureViewDescriptor {
                         label: Some("Framebuffer Texture view"),
-                        format: Some(*color_format),
+                        format: Some(attachment.color_format),
                         dimension: Some(wgpu::TextureViewDimension::D2),
                         aspect: wgpu::TextureAspect::All,
                         base_mip_level: 0,
@@ -211,23 +208,53 @@ impl Framebuffer {
                         base_array_layer: 0,
                         array_layer_count: None,
                     });
-                    *texture_view = Some(tex_view);
+                    output_view = Some(tex_view);
                     *color_texture = Some(texture);
                 }
             }
+
+            if self.sample_count > 1 {
+                let msaa_texture = device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("Framebuffer MSAA Texture"),
+                    size: wgpu::Extent3d {
+                        width: self.resolution.0,
+                        height: self.resolution.1,
+                        depth: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: self.sample_count,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: surface_colorformat,
+                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                });
+                let msaa_view =
+                    Some(msaa_texture.create_view(&wgpu::TextureViewDescriptor::default()));
+
+                attachment.assembled = Some(ColorAttachmentAssembled {
+                    multisample_texture: Some(msaa_texture),
+                    attachment_view: msaa_view,
+                    resolve_view: output_view,
+                });
+            } else {
+                attachment.assembled = Some(ColorAttachmentAssembled {
+                    multisample_texture: None,
+                    attachment_view: output_view,
+                    resolve_view: None,
+                });
+            }
         }
 
-        if let Some(depth_format) = self.configuration.depth_format {
-            self.depth_texture_view = Some(
+        if let Some(depth_format) = self.depth_stencil_format {
+            self.depth_stencil_view = Some(
                 device
                     .create_texture(&wgpu::TextureDescriptor {
                         size: wgpu::Extent3d {
-                            width: self.configuration.width(),
-                            height: self.configuration.height(),
+                            width: self.width(),
+                            height: self.height(),
                             depth: 1,
                         },
                         mip_level_count: 1,
-                        sample_count: 1,
+                        sample_count: self.sample_count,
                         dimension: wgpu::TextureDimension::D2,
                         format: depth_format,
                         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
@@ -238,14 +265,20 @@ impl Framebuffer {
         }
     }
 
-    // pub fn color_format(&self) -> Option<wgpu::TextureFormat> {
-    //     // TODO:
-    //     Some(wgpu::TextureFormat::Bgra8UnormSrgb)
-    //     // Some(wgpu::TextureFormat::Bgra8Unorm)
-    // }
-    // pub fn sample_count(&self) -> u32 {
-    //     1 // TODO:
-    // }
+    // Check if there is a live swapchain frame
+    pub fn needs_present(&self) -> bool {
+        !self.live_frame.is_empty()
+    }
+
+    // If the Framebuffer has an live swapchain frame, present it.
+    // Needs to be called between after the last render pass that uses it
+    // is submitted (but before acquiring a new one)
+    pub fn present(&mut self) {
+        debug_assert!(self.needs_present());
+
+        // wgpu currently present on Drop
+        self.live_frame.clear();
+    }
 
     pub fn begin_render_pass<'a>(
         &'a mut self,
@@ -255,78 +288,98 @@ impl Framebuffer {
         // dropped before self or encoder, as the RenderPass will refer to
         // values in them
 
+        debug_assert!(self.live_frame.is_empty());
+        assert!(!self.dirty, "Framebuffer was modified but not reconfigured");
+
         let mut color_attachments = Vec::new();
 
-        // TODO: retain the vec, update only when dirty or surface attachment
-        for attachment in &mut self.attachments {
-            match attachment {
-                FramebufferAttachment::Surface {
-                    surface: _,
-                    swap_chain,
-                    ref mut frame,
-                } => {
-                    let swap_chain = swap_chain.as_mut().expect(
+        // Start acquire the swapchain frames in separate loop,
+        // so that we can mutate self to store them, when the
+        // renderpass borrows it
+        for attachment in &self.color_attachments {
+            match &attachment.data {
+                ColorAttachmentData::Surface { swap_chain, .. } => {
+                    let swap_chain = swap_chain.as_ref().expect(
                     "swap chain is missing, did you remember to call `resize` before `begin_render_pass`",
                 );
-                    *frame = None;
                     let new_frame = swap_chain
                         .get_current_frame()
                         .expect("Timeout when acquiring next swap chain texture");
 
-                    *frame = Some(new_frame);
-                    let frame_view = &frame.as_mut().unwrap().output.view;
-                    color_attachments.push(wgpu::RenderPassColorAttachmentDescriptor {
-                        attachment: frame_view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color {
-                                r: self.clear_color[0],
-                                g: self.clear_color[1],
-                                b: self.clear_color[2],
-                                a: self.clear_color[3],
-                            }),
-                            store: true,
-                        },
-                    });
+                    self.live_frame.push(new_frame);
                 }
-                FramebufferAttachment::Texture {
-                    color_texture: _,
-                    color_format: _,
-                    texture_view,
-                } => {
-                    color_attachments.push(wgpu::RenderPassColorAttachmentDescriptor {
-                        attachment: &texture_view.as_ref().expect("Texture not configured"),
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color {
-                                r: self.clear_color[0],
-                                g: self.clear_color[1],
-                                b: self.clear_color[2],
-                                a: self.clear_color[3],
-                            }),
-                            store: true,
-                        },
-                    });
-                }
+                _ => {}
             }
         }
 
-        let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            color_attachments: &color_attachments,
-            depth_stencil_attachment: self.depth_texture_view.as_ref().map(|tex| {
-                wgpu::RenderPassDepthStencilAttachmentDescriptor {
-                    attachment: tex,
-                    depth_ops: Some(wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(1.0),
-                        store: false,
-                    }),
-                    stencil_ops: Some(wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(0),
-                        store: false,
-                    }),
+        let mut swapchain_idx = 0;
+        // TODO: retain the vec, update only when dirty or surface attachment
+        for attachment in &self.color_attachments {
+            let attachment_view;
+            let resolve_view;
+            match &attachment.data {
+                ColorAttachmentData::Surface { .. } => {
+                    let frame_view = &self.live_frame.get(swapchain_idx).unwrap().output.view;
+
+                    let assembled = attachment
+                        .assembled
+                        .as_ref()
+                        .expect("Unconfigured attachment, did you call assemble()?");
+
+                    if assembled.attachment_view.is_some() {
+                        attachment_view = assembled.attachment_view.as_ref().unwrap();
+                        resolve_view = Some(frame_view);
+                    } else {
+                        attachment_view = frame_view;
+                        resolve_view = None;
+                    }
+
+                    swapchain_idx += 1;
                 }
-            }),
+                ColorAttachmentData::Texture { color_texture: _ } => {
+                    attachment_view = attachment
+                        .assembled
+                        .as_ref()
+                        .unwrap()
+                        .attachment_view
+                        .as_ref()
+                        .unwrap();
+                    resolve_view = attachment.assembled.as_ref().unwrap().resolve_view.as_ref();
+                }
+            }
+
+            color_attachments.push(wgpu::RenderPassColorAttachmentDescriptor {
+                attachment: attachment_view,
+                resolve_target: resolve_view,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: attachment.clear_color[0],
+                        g: attachment.clear_color[1],
+                        b: attachment.clear_color[2],
+                        a: attachment.clear_color[3],
+                    }),
+                    store: true,
+                },
+            });
+        }
+
+        let depth_stencil_attachment = self.depth_stencil_view.as_ref().map(|tex| {
+            wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                attachment: tex,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: false,
+                }),
+                stencil_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(0),
+                    store: false,
+                }),
+            }
         });
-        pass
+
+        encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            color_attachments: &color_attachments,
+            depth_stencil_attachment: depth_stencil_attachment,
+        })
     }
 }

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,45 +1,110 @@
+#[derive(Debug)]
+enum FramebufferTarget {
+    Surface {
+        surface: wgpu::Surface,
+        swap_chain: Option<wgpu::SwapChain>,
+        frame: Option<wgpu::SwapChainFrame>,
+    },
+    Texture {
+        color_format: wgpu::TextureFormat,
+        color_texture: Option<wgpu::Texture>,
+        texture_view: Option<wgpu::TextureView>,
+    },
+}
+#[derive(Debug)]
 pub struct Framebuffer {
-    surface: wgpu::Surface,
-    swap_chain: Option<wgpu::SwapChain>,
-    frame: Option<wgpu::SwapChainOutput>,
+    target: FramebufferTarget,
+    // surface: wgpu::Surface,
+    // swap_chain: Option<wgpu::SwapChain>,
     depth_texture_view: Option<wgpu::TextureView>,
     clear_color: [f64; 4],
-    resolution: (u32, u32),
+    //    resolution: (u32, u32),
+    configuration: FramebufferConfiguration,
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+pub struct FramebufferConfiguration {
+    pub resolution: (u32, u32),
+    pub depth_format: Option<wgpu::TextureFormat>,
+}
+
+impl FramebufferConfiguration {
+    pub fn with_resolution(&self, width: u32, height: u32) -> FramebufferConfiguration {
+        let mut ret = self.clone();
+        ret.resolution = (width, height);
+        ret
+    }
+    pub fn with_depth_format(&self, depth_format: wgpu::TextureFormat) -> FramebufferConfiguration {
+        let mut ret = self.clone();
+        ret.depth_format = Some(depth_format);
+        ret
+    }
+    pub fn with_no_depth(&self) -> FramebufferConfiguration {
+        let mut ret = self.clone();
+        ret.depth_format = None;
+        ret
+    }
+    pub fn width(&self) -> u32 {
+        self.resolution.0
+    }
+    pub fn height(&self) -> u32 {
+        self.resolution.1
+    }
 }
 
 impl Framebuffer {
-    pub fn new<W: raw_window_handle::HasRawWindowHandle>(
+    pub fn new_from_window<W: raw_window_handle::HasRawWindowHandle>(
         instance: &wgpu::Instance,
         window: &W,
     ) -> Framebuffer {
         let surface = unsafe { instance.create_surface(window) };
-
+        Self::new_from_surface(surface)
+    }
+    pub fn new_from_surface(surface: wgpu::Surface) -> Framebuffer {
         Framebuffer {
-            surface,
-            swap_chain: None,
-            frame: None,
+            target: FramebufferTarget::Surface {
+                surface,
+                swap_chain: None,
+                frame: None,
+            },
             depth_texture_view: None,
             clear_color: [0f64, 0f64, 0f64, 1f64],
-            resolution: (0, 0),
+            configuration: FramebufferConfiguration::default(), //            resolution: (0, 0),
         }
+    }
+
+    pub fn new_texture(color_format: wgpu::TextureFormat) -> Framebuffer {
+        Framebuffer {
+            target: FramebufferTarget::Texture {
+                color_format,
+                color_texture: None,
+                texture_view: None,
+            },
+            depth_texture_view: None,
+            clear_color: [0f64, 0f64, 0f64, 1f64],
+            configuration: FramebufferConfiguration::default(),
+        }
+    }
+
+    pub fn configuration(&self) -> &FramebufferConfiguration {
+        &self.configuration
     }
 
     pub fn set_clear_color(&mut self, clear_color: &[f64; 4]) {
         self.clear_color = *clear_color;
     }
 
-    pub fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32, depth_enabled: bool) {
-        if width == self.resolution.0
-            && height == self.resolution.1
-            && depth_enabled == self.depth_texture_view.is_some()
-        {
+    pub fn reconfigure(
+        &mut self,
+        device: &wgpu::Device,
+        new_configuration: &FramebufferConfiguration,
+    ) {
+        if new_configuration == &self.configuration {
             // Nothing changed
             return;
         }
 
-        self.frame = None;
-
-        self.resolution = (width, height);
+        self.configuration = new_configuration.clone(); //resolution = (width, height);
         let sc_desc = wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             // TODO: Allow srgb unconditionally
@@ -48,32 +113,81 @@ impl Framebuffer {
             } else {
                 wgpu::TextureFormat::Bgra8UnormSrgb
             },
-            width: width,
-            height: height,
+            width: self.configuration.width(),
+            height: self.configuration.height(),
             present_mode: wgpu::PresentMode::Mailbox,
         };
-        let swap_chain = device.create_swap_chain(&self.surface, &sc_desc);
-        self.swap_chain = Some(swap_chain);
+        match &mut self.target {
+            FramebufferTarget::Surface {
+                ref mut surface,
+                ref mut swap_chain,
+                ref mut frame,
+            } => {
+                *frame = None; // SwapChainFrame must be dropped debug creating creating new swapchain
+                let new_swap_chain = device.create_swap_chain(&surface, &sc_desc);
+                *swap_chain = Some(new_swap_chain);
+            }
+            FramebufferTarget::Texture {
+                ref color_format,
+                ref mut color_texture,
+                ref mut texture_view,
+            } => {
+                let texture = device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("Framebuffer Texture"),
+                    size: wgpu::Extent3d {
+                        width: self.configuration.width(),
+                        height: self.configuration.height(),
+                        depth: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: *color_format,
+                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT | wgpu::TextureUsage::SAMPLED,
+                });
+                let tex_view = texture.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some("Framebuffer Texture view"),
+                    format: Some(*color_format),
+                    dimension: Some(wgpu::TextureViewDimension::D2),
+                    aspect: wgpu::TextureAspect::All,
+                    base_mip_level: 0,
+                    level_count: None,
+                    base_array_layer: 0,
+                    array_layer_count: None,
+                });
+                *texture_view = Some(tex_view);
+                *color_texture = Some(texture);
+            }
+        }
 
-        if depth_enabled {
+        if let Some(depth_format) = self.configuration.depth_format {
             self.depth_texture_view = Some(
                 device
                     .create_texture(&wgpu::TextureDescriptor {
                         size: wgpu::Extent3d {
-                            width: width,
-                            height: height,
+                            width: self.configuration.width(),
+                            height: self.configuration.height(),
                             depth: 1,
                         },
                         mip_level_count: 1,
                         sample_count: 1,
                         dimension: wgpu::TextureDimension::D2,
-                        format: wgpu::TextureFormat::Depth24Plus,
+                        format: depth_format,
                         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                         label: Some("wgpu-util depth texture"),
                     })
-                    .create_default_view(),
+                    .create_view(&wgpu::TextureViewDescriptor::default()),
             );
         }
+    }
+
+    pub fn color_format(&self) -> Option<wgpu::TextureFormat> {
+        // TODO:
+        Some(wgpu::TextureFormat::Bgra8UnormSrgb)
+        // Some(wgpu::TextureFormat::Bgra8Unorm)
+    }
+    pub fn sample_count(&self) -> u32 {
+        1 // TODO:
     }
 
     pub fn begin_render_pass<'a>(
@@ -84,42 +198,112 @@ impl Framebuffer {
         // dropped before self or encoder, as the RenderPass will refer to
         // values in them
 
-        let swap_chain = self.swap_chain.as_mut().expect(
-            "swap chain is missing, did you remember to call `resize` before `begin_render_pass`",
-        );
-        self.frame = None;
-        let frame = swap_chain
-            .get_next_texture()
-            .expect("Timeout when acquiring next swap chain texture");
+        match &mut self.target {
+            FramebufferTarget::Surface {
+                surface: _,
+                swap_chain,
+                ref mut frame,
+            } => {
+                let swap_chain = swap_chain.as_mut().expect(
+                    "swap chain is missing, did you remember to call `resize` before `begin_render_pass`",
+                );
+                *frame = None;
+                let new_frame = swap_chain
+                    .get_current_frame()
+                    .expect("Timeout when acquiring next swap chain texture");
 
-        self.frame = Some(frame);
-        let frame_view = &self.frame.as_mut().unwrap().view;
+                *frame = Some(new_frame);
+                let frame_view = &frame.as_mut().unwrap().output.view;
 
-        let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: frame_view,
                 resolve_target: None,
-                load_op: wgpu::LoadOp::Clear,
-                store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color {
-                    r: self.clear_color[0],
-                    g: self.clear_color[1],
-                    b: self.clear_color[2],
-                    a: self.clear_color[3],
-                },
-            }],
-            depth_stencil_attachment: self.depth_texture_view.as_ref().map(|tex| {
-                wgpu::RenderPassDepthStencilAttachmentDescriptor {
-                    attachment: tex,
-                    depth_load_op: wgpu::LoadOp::Clear,
-                    depth_store_op: wgpu::StoreOp::Store,
-                    stencil_load_op: wgpu::LoadOp::Clear,
-                    stencil_store_op: wgpu::StoreOp::Store,
-                    clear_depth: 1.0,
-                    clear_stencil: 0,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: self.clear_color[0],
+                        g: self.clear_color[1],
+                        b: self.clear_color[2],
+                        a: self.clear_color[3],
+                    }),
+                    store: true
                 }
-            }),
-        });
-        pass
+                // load_op: wgpu::LoadOp::Clear,
+                // store_op: wgpu::StoreOp::Store,
+                // clear_color: wgpu::Color {
+                //     r: self.clear_color[0],
+                //     g: self.clear_color[1],
+                //     b: self.clear_color[2],
+                //     a: self.clear_color[3],
+                // },
+            }],
+                    depth_stencil_attachment: self.depth_texture_view.as_ref().map(|tex| {
+                        wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                            attachment: tex,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: false,
+                            }),
+                            stencil_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(0),
+                                store: false,
+                            }),
+                            // depth_load_op: wgpu::LoadOp::Clear,
+                            // depth_store_op: wgpu::StoreOp::Store,
+                            // stencil_load_op: wgpu::LoadOp::Clear,
+                            // stencil_store_op: wgpu::StoreOp::Store,
+                            // clear_depth: 1.0,
+                            // clear_stencil: 0,
+                            // depth_read_only: false,
+                            // stencil_read_only: false,
+                        }
+                    }),
+                });
+                pass
+            }
+            FramebufferTarget::Texture {
+                color_texture: _,
+                color_format: _,
+                texture_view,
+            } => {
+                let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: &texture_view.as_ref().expect("Texture not configured"),
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color {
+                                r: self.clear_color[0],
+                                g: self.clear_color[1],
+                                b: self.clear_color[2],
+                                a: self.clear_color[3],
+                            }),
+                            store: true,
+                        },
+                    }],
+                    depth_stencil_attachment: self.depth_texture_view.as_ref().map(|tex| {
+                        wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                            attachment: tex,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: false,
+                            }),
+                            stencil_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(0),
+                                store: false,
+                            }),
+                            // depth_load_op: wgpu::LoadOp::Clear,
+                            // depth_store_op: wgpu::StoreOp::Store,
+                            // stencil_load_op: wgpu::LoadOp::Clear,
+                            // stencil_store_op: wgpu::StoreOp::Store,
+                            // clear_depth: 1.0,
+                            // clear_stencil: 0,
+                            // depth_read_only: false,
+                            // stencil_read_only: false,
+                        }
+                    }),
+                });
+                pass
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 mod async_block;
 mod framebuffer;
+// mod shapes;
 
 pub use wgpu;
 
 pub use async_block::block_on;
 pub use framebuffer::Framebuffer;
+
+// pub use shapes::Shapes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod async_block;
 mod framebuffer;
 
+pub use wgpu;
+
 pub use async_block::block_on;
 pub use framebuffer::Framebuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
-
 mod async_block;
+mod framebuffer;
+
 pub use async_block::block_on;
+pub use framebuffer::Framebuffer;


### PR DESCRIPTION
Handles the creation of the swap chain, depth texture and
also the renderpass.

I'd like comments on,
0) would you use it?
1) `resize` got to be a bit overloaded after I added depth, and I can see it growing with more features, but I kind of like the explicitness of it. Perhaps calling it `reconfigure` would help?
2) I was going to have setters like `set_depth_enabled(bool)` type of methods, and either eagerly or lazily recreate the swap chains/texture, but then I need the `wgpu::Device` instance in more places, the single `resize/reconfigure` is a nice place to have it, is it okay to ask to call it separately after user has changed flags? Or perhaps a configuration structure that is passed to `reconfigure` that has all the state (and user can persist?)

Future improvements would likely be stuff like, msaa, stencil, setting of the pixelformats etc., but those I see mostly as additive features.
